### PR TITLE
Update to Kotlin 1.3-M2 (and stable coroutines)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.okkero.skedule</groupId>
     <artifactId>skedule</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Skedule</name>
@@ -24,7 +24,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.1.51</kotlin.version>
+        <kotlin.version>1.3-M2</kotlin.version>
         <junit.version>4.12</junit.version>
         <dokka.version>0.9.9</dokka.version>
     </properties>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
-            <version>0.19.1</version>
+            <version>0.26.0-eap13</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -97,8 +97,8 @@
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
                 <configuration>
-                    <apiVersion>1.1</apiVersion>
-                    <languageVersion>1.1</languageVersion>
+                    <apiVersion>1.3</apiVersion>
+                    <languageVersion>1.3</languageVersion>
                     <jvmTarget>1.8</jvmTarget>
                     <args>
                         <arg>-Xcoroutines=enable</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
+            <id>kotlin-dev</id>
+            <url>https://dl.bintray.com/kotlin/kotlin-dev/</url>
+        </repository>
+        <repository>
             <id>jcenter</id>
             <name>JCenter</name>
             <url>https://jcenter.bintray.com/</url>
@@ -45,6 +49,10 @@
             <id>jcenter</id>
             <name>JCenter</name>
             <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>kotlin-dev</id>
+            <url>https://dl.bintray.com/kotlin/kotlin-dev/</url>
         </pluginRepository>
     </pluginRepositories>
     <dependencies>

--- a/src/main/kotlin/com/okkero/skedule/BukkitDispatcher.kt
+++ b/src/main/kotlin/com/okkero/skedule/BukkitDispatcher.kt
@@ -1,14 +1,14 @@
 package com.okkero.skedule
 
-import kotlinx.coroutines.experimental.CancellableContinuation
-import kotlinx.coroutines.experimental.CoroutineDispatcher
-import kotlinx.coroutines.experimental.Delay
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Delay
 import org.bukkit.Bukkit
 import org.bukkit.plugin.Plugin
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.scheduler.BukkitTask
 import java.util.concurrent.TimeUnit
-import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.CoroutineContext
 
 private val bukkitScheduler
     get() = Bukkit.getScheduler()

--- a/src/main/kotlin/com/okkero/skedule/SchedulerCoroutine.kt
+++ b/src/main/kotlin/com/okkero/skedule/SchedulerCoroutine.kt
@@ -1,14 +1,16 @@
 package com.okkero.skedule
 
 import com.okkero.skedule.SynchronizationContext.*
-import kotlinx.coroutines.experimental.Unconfined
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.bukkit.Bukkit
 import org.bukkit.plugin.Plugin
 import org.bukkit.scheduler.BukkitScheduler
 import org.bukkit.scheduler.BukkitTask
-import kotlin.coroutines.experimental.RestrictsSuspension
-import kotlin.coroutines.experimental.suspendCoroutine
+import kotlin.coroutines.RestrictsSuspension
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 fun Plugin.schedule(initialContext: SynchronizationContext = SYNC,
                     co: suspend BukkitSchedulerController.() -> Unit): CoroutineTask {
@@ -28,7 +30,7 @@ fun Plugin.schedule(initialContext: SynchronizationContext = SYNC,
 fun BukkitScheduler.schedule(plugin: Plugin, initialContext: SynchronizationContext = SYNC,
                              co: suspend BukkitSchedulerController.() -> Unit): CoroutineTask {
     val controller = BukkitSchedulerController(plugin, this)
-    launch(Unconfined) {
+    GlobalScope.launch(Dispatchers.Unconfined) {
         try {
             controller.start(initialContext)
             controller.co()
@@ -48,7 +50,6 @@ fun BukkitScheduler.schedule(plugin: Plugin, initialContext: SynchronizationCont
  * @property currentTask the task that is currently executing within the context of this coroutine
  * @property isRepeating whether this coroutine is currently backed by a repeating task
  */
-@RestrictsSuspension
 class BukkitSchedulerController(val plugin: Plugin, val scheduler: BukkitScheduler) {
 
     private var schedulerDelegate: TaskScheduler = NonRepeatingTaskScheduler(plugin, scheduler)


### PR DESCRIPTION
I tested it on my server, it works fine.

It is a breaking change, any plugin that was using Skedule will need to be updated (if they didn't do anything super extraordinary with the API, recompiling against the new JAR should work).

Also, I'm not sure why, but with the `@RestrictsSuspension` annotation it wasn't compiling correctly, I need to check why later.

Fixes #11