### PR TITLE
Added Maven Source Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,10 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
                 <version>${dokka.version}</version>


### PR DESCRIPTION
Applying the Maven Source Plugin allows the project to include it's sources as a maven source artifact, and allows for better debugging/browsing when this is used as a maven dependency, specially because many IDEs allows for browsing a dependency's source code if it's available.